### PR TITLE
fix: swagger tag added, additionalTags null fix

### DIFF
--- a/src/adapters/esamwad/announcements.adapter.ts
+++ b/src/adapters/esamwad/announcements.adapter.ts
@@ -223,7 +223,7 @@ export class AnnouncementsEsamwadService implements IServicelocator {
         }
         `,
       variables: {
-        additional_tags: `{${announcementsData?.additionalTags?.toString()}}`,
+        additional_tags: announcementsData?.additionalTags?.toString(),
         data: announcementsData.data,
         is_dismissable:
           announcementsData.pinnedAnnouncementProperties?.is_dismissable,

--- a/src/announcements/announcements.controller.ts
+++ b/src/announcements/announcements.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiOkResponse,
+  ApiTags,
 } from "@nestjs/swagger";
 import { IServicelocator } from "src/adapters/announcementsservicelocator";
 import {
@@ -32,6 +33,7 @@ import {
 import { AnnouncementsFilterDto } from "./dto/announcements-filter.dto";
 import { AnnouncementsDto } from "./dto/announcements.dto";
 
+@ApiTags("Announcements")
 @Controller("announcements")
 export class AnnouncementsController {
   constructor(


### PR DESCRIPTION
### **Changes**

1. Added Swagger API tag for announcements APIs
2.  Bugfix for additionalTags
          
      **Test**: When additionalTags is undefined during creation of announcement, value of additional_tags being set as ["undefined"] in DB
      
      **Expected**: Value in DB should be set as NULL
      
      **Fix**: removed template literals to send empty array in case of undefined value to DB
      
      
CC: @Shruti3004 @coolbung 