### PR TITLE
API modifitions for Track Assessment & Monitor APIs

### DIFF
--- a/src/adapters/hasura/monitorTracking.adapter.ts
+++ b/src/adapters/hasura/monitorTracking.adapter.ts
@@ -146,6 +146,7 @@ export class MonitorTrackingService {
     monitorTrackingId: string,
     monitorId: string,
     schoolId: string,
+    groupId: string,
     scheduleVisitDate: Date,
     visitDate: Date,
     request: any
@@ -156,6 +157,7 @@ export class MonitorTrackingService {
       monitorTrackingId,
       monitorId,
       schoolId,
+      groupId,
       scheduleVisitDate,
       visitDate,
     };
@@ -176,6 +178,7 @@ export class MonitorTrackingService {
               scheduleVisitDate
               status
               schoolId
+              groupId
               monitorId
               updated_at
               visitDate

--- a/src/adapters/hasura/monitorTracking.adapter.ts
+++ b/src/adapters/hasura/monitorTracking.adapter.ts
@@ -54,13 +54,14 @@ export class MonitorTrackingService {
   ) {
     var axios = require("axios");
     var data = {
-      query: `mutation CreateMonitorTracking($schoolId:String,$monitorId:String,$scheduleVisit:date,$visitDate:date, $feedback:String, $status:String) {
-        insert_monitortracking_one(object: {schoolId: $schoolId, monitorId:$monitorId,scheduleVisitDate: $scheduleVisit, visitDate:$visitDate, feedback: $feedback, status: $status}) {
+      query: `mutation CreateMonitorTracking($schoolId:String,$groupId:String,$monitorId:String,$scheduleVisit:date,$visitDate:date, $feedback:String, $status:String) {
+        insert_monitortracking_one(object: {schoolId: $schoolId, groupId: $groupId, monitorId:$monitorId,scheduleVisitDate: $scheduleVisit, visitDate:$visitDate, feedback: $feedback, status: $status}) {
           monitorTrackingId
         }
       }`,
       variables: {
         schoolId: monitorTrackingDto.schoolId,
+        groupId: monitorTrackingDto.groupId,
         monitorId: monitorTrackingDto.monitorId,
         scheduleVisit: monitorTrackingDto.scheduleVisitDate,
         visitDate: monitorTrackingDto.visitDate,
@@ -96,6 +97,7 @@ export class MonitorTrackingService {
     var axios = require("axios");
     const updateData = {
       schoolId: monitorTrackingDto.schoolId,
+      groupId: monitorTrackingDto.groupId,
       monitorId: monitorTrackingDto.monitorId,
       scheduleVisitDate: monitorTrackingDto.scheduleVisitDate,
       visitDate: monitorTrackingDto.visitDate,

--- a/src/adapters/hasura/trackassessment.adapter.ts
+++ b/src/adapters/hasura/trackassessment.adapter.ts
@@ -5,6 +5,7 @@ import { catchError, map } from "rxjs";
 import { SuccessResponse } from "src/success-response";
 import { TrackAssessmentDto } from "src/trackAssessment/dto/trackassessment.dto";
 import { ErrorResponse } from "src/error-response";
+import { StudentAssessmentStatus } from "../../trackAssessment/enums/statuses.enum";
 
 @Injectable()
 export class TrackAssessmentService {
@@ -32,6 +33,7 @@ export class TrackAssessmentService {
         groupId
         subject
         type
+        studentAssessmentStatus
       }
     }`,
         variables: {
@@ -68,50 +70,48 @@ export class TrackAssessmentService {
     request: any,
     assessmentDto: TrackAssessmentDto
   ) {
-    var axios = require("axios");
+    let variables: object;
     try {
-      let answer = JSON.stringify(assessmentDto.answersheet);
-      var jsonObj = JSON.parse(answer);
-      let params = JSON.parse(jsonObj);
+      const axios = require("axios");
+      if (
+        assessmentDto.studentAssessmentStatus ==
+        StudentAssessmentStatus.COMPLETED
+      ) {
+        const answer = JSON.stringify(assessmentDto.answersheet);
+        const jsonObj = JSON.parse(answer);
+        const params = JSON.parse(jsonObj);
 
-      let sum = 0;
+        let sum = 0;
+        params.children.map((e: any) => {
+          sum += e.score;
+          return sum;
+        });
+        assessmentDto.score = sum.toString();
 
-      params.children.map((e: any) => {
-        sum += e.score;
-        return sum;
-      });
-      assessmentDto.score = sum.toString();
+        const questionIds = assessmentDto.questions;
+        const totalScoreArray = [];
+        for (const value of questionIds) {
+          const config = {
+            method: "get",
+            url: `${this.url}/question/v1/read/${value}?fields=maxScore`,
+          };
+          const response = await axios(config);
+          const data = response?.data;
+          const final = data.result.question;
 
-      const questionIds = assessmentDto.questions;
-      let totalScoreArray = [];
-      for (let value of questionIds) {
-        let config = {
-          method: "get",
-          url: `${this.url}/question/v1/read/${value}?fields=maxScore`,
-        };
-        const response = await axios(config);
-        const data = response?.data;
-        const final = data.result.question;
+          const scoreResponse = {
+            maxScore: final.maxScore,
+          };
+          totalScoreArray.push(scoreResponse);
+        }
+        let totalScore = 0;
+        totalScoreArray.map((e: any) => {
+          totalScore += e.maxScore;
+          return totalScore;
+        });
+        assessmentDto.totalScore = totalScore.toString();
 
-        const scoreResponse = {
-          maxScore: final.maxScore,
-        };
-        totalScoreArray.push(scoreResponse);
-      }
-      let totalScore = 0;
-      totalScoreArray.map((e: any) => {
-        totalScore += e.maxScore;
-        return totalScore;
-      });
-      assessmentDto.totalScore = totalScore.toString();
-
-      var data = {
-        query: `mutation CreateTrackAssessment($filter: String, $score: String, $totalScore:String, $source: String, $questions: String, $studentId: String, $teacherId: String, $type: String, $answersheet: String,$groupId:String, $subject:String) {
-      insert_trackassessment_one(object:{filter: $filter, score: $score, totalScore:$totalScore, source: $source, questions: $questions, studentId: $studentId, teacherId: $teacherId, type: $type, answersheet: $answersheet,groupId:$groupId,subject:$subject}) {
-        trackAssessmentId
-      }
-    }`,
-        variables: {
+        variables = {
           filter: assessmentDto.filter,
           source: assessmentDto.source,
           questions: assessmentDto.questions.toString(),
@@ -123,10 +123,35 @@ export class TrackAssessmentService {
           totalScore: assessmentDto.totalScore,
           groupId: assessmentDto.groupId,
           subject: assessmentDto.subject,
-        },
+          studentAssessmentStatus: assessmentDto.studentAssessmentStatus,
+        };
+      } else {
+        variables = {
+          filter: null,
+          source: null,
+          questions: null,
+          studentId: assessmentDto.studentId,
+          teacherId: assessmentDto.teacherId,
+          type: assessmentDto.type,
+          answersheet: null,
+          score: null,
+          totalScore: null,
+          groupId: assessmentDto.groupId,
+          subject: null,
+          studentAssessmentStatus: assessmentDto.studentAssessmentStatus,
+        };
+      }
+
+      const data = {
+        query: `mutation CreateTrackAssessment($filter: String, $score: String, $totalScore:String, $source: String, $questions: String, $studentId: String, $teacherId: String, $type: String, $answersheet: String,$groupId:String, $subject:String, $studentAssessmentStatus: String) {
+          insert_trackassessment_one(object:{filter: $filter, score: $score, totalScore:$totalScore, source: $source, questions: $questions, studentId: $studentId, teacherId: $teacherId, type: $type, answersheet: $answersheet,groupId:$groupId,subject:$subject, studentAssessmentStatus: $studentAssessmentStatus}) {
+            trackAssessmentId
+          }
+        }`,
+        variables: variables,
       };
 
-      var config = {
+      const config = {
         method: "post",
         url: process.env.REGISTRYHASURA,
         headers: {
@@ -189,6 +214,7 @@ export class TrackAssessmentService {
     groupId
     subject
     type
+    studentAssessmentStatus
   }
 }`,
       variables: {
@@ -265,6 +291,7 @@ export class TrackAssessmentService {
           subject
           type
           date    
+          studentAssessmentStatus
         }
       }`,
       variables: filterVariables,

--- a/src/adapters/hasura/trackassessment.adapter.ts
+++ b/src/adapters/hasura/trackassessment.adapter.ts
@@ -223,13 +223,34 @@ export class TrackAssessmentService {
     toDate: string,
     groupId: string,
     subject: string,
+    teacherId: string,
+    studentId: string,
     request: any
   ) {
     var axios = require("axios");
+    const filterParams = {
+      groupId,
+      subject,
+      teacherId,
+      studentId,
+    };
+
+    // TODO: fix fromDate/toDate filters post confirmation
+    const filterVariables = {
+      fromDate: fromDate,
+      toDate: toDate,
+    };
+    let filterParamsString = "";
+    Object.keys(filterParams).forEach((e) => {
+      if (filterParams[e] && filterParams[e] != "") {
+        filterParamsString += `,${e}:{_eq:$${e}}`;
+        filterVariables[e] = filterParams[e];
+      }
+    });
 
     var data = {
-      query: `query AssessmentFilter($fromDate:date,$toDate:date,$groupId:String,$subject:String) {
-        trackassessment(where: {date: {_gte: $fromDate}, _and: {date: {_lte: $toDate}},groupId: {_eq: $groupId},subject: {_eq: $subject}}) {
+      query: `query AssessmentFilter($fromDate:date,$toDate:date,$groupId:String,$subject:String, $teacherId:String, $studentId: String) {
+        trackassessment(where: {date: {_gte: $fromDate}, _and: {date: {_lte: $toDate}} ${filterParamsString} }) {
           answersheet
           filter
           created_at
@@ -247,12 +268,7 @@ export class TrackAssessmentService {
           date    
         }
       }`,
-      variables: {
-        fromDate: fromDate,
-        toDate: toDate,
-        groupId: groupId,
-        subject: subject,
-      },
+      variables: filterVariables,
     };
 
     var config = {

--- a/src/adapters/hasura/trackassessment.adapter.ts
+++ b/src/adapters/hasura/trackassessment.adapter.ts
@@ -235,10 +235,9 @@ export class TrackAssessmentService {
       studentId,
     };
 
-    // TODO: fix fromDate/toDate filters post confirmation
     const filterVariables = {
-      fromDate: fromDate,
-      toDate: toDate,
+      fromDate: fromDate, // as these are required fields, let's initialize them
+      toDate: toDate, // as these are required fields, let's initialize them
     };
     let filterParamsString = "";
     Object.keys(filterParams).forEach((e) => {

--- a/src/monitorTracking/dto/monitorTracking.dto.ts
+++ b/src/monitorTracking/dto/monitorTracking.dto.ts
@@ -13,6 +13,10 @@ export class MonitorTrackingDto {
   @Expose()
   schoolId: string;
 
+  @ApiProperty({ description: "Group ID (class ID)" })
+  @Expose()
+  groupId: string;
+
   @ApiProperty({
     default: new Date().toISOString().split("T")[0],
   })
@@ -51,6 +55,7 @@ export class MonitorTrackingDto {
       : "";
     this.monitorId = obj?.monitorId ? `${obj.monitorId}` : "";
     this.schoolId = obj?.schoolId ? `${obj.schoolId}` : "";
+    this.groupId = obj?.groupId ? `${obj.groupId}` : "";
     this.scheduleVisitDate = obj?.scheduleVisitDate
       ? `${obj.scheduleVisitDate}`
       : "";

--- a/src/monitorTracking/monitorTracking.controller.ts
+++ b/src/monitorTracking/monitorTracking.controller.ts
@@ -84,6 +84,7 @@ export class MonitorTrackingController {
   @ApiQuery({ name: "monitorTrackingId", required: false })
   @ApiQuery({ name: "monitorId", required: false })
   @ApiQuery({ name: "schoolId", required: false })
+  @ApiQuery({ name: "groupId", required: false })
   @ApiQuery({ name: "scheduleVisitDate", required: false })
   @ApiQuery({ name: "visitDate", required: false })
   public async searchMonitorTracking(
@@ -91,6 +92,7 @@ export class MonitorTrackingController {
     @Query("monitorTrackingId") monitorTrackingId: string,
     @Query("monitorId") monitorId: string,
     @Query("schoolId") schoolId: string,
+    @Query("groupId") groupId: string,
     @Query("scheduleVisitDate") scheduleVisitDate: Date,
     @Query("visitDate") visitDate: Date,
     @Req() request: Request
@@ -100,6 +102,7 @@ export class MonitorTrackingController {
       monitorTrackingId,
       monitorId,
       schoolId,
+      groupId,
       scheduleVisitDate,
       visitDate,
       request

--- a/src/trackAssessment/dto/trackassessment.dto.ts
+++ b/src/trackAssessment/dto/trackassessment.dto.ts
@@ -1,5 +1,7 @@
-import { Exclude, Expose } from "class-transformer";
+import { Expose } from "class-transformer";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsIn, IsNotEmpty, IsString } from "class-validator";
+import { StudentAssessmentStatus } from "../enums/statuses.enum";
 
 export class TrackAssessmentDto {
   @Expose()
@@ -69,6 +71,17 @@ export class TrackAssessmentDto {
   @Expose()
   date: string;
 
+  @IsString()
+  @IsNotEmpty()
+  @IsIn([StudentAssessmentStatus.COMPLETED, StudentAssessmentStatus.ABSENT])
+  @ApiProperty({
+    description:
+      "Student Assessment Status - whether student was absent or he has completed the assessment.",
+    enum: [StudentAssessmentStatus.COMPLETED, StudentAssessmentStatus.ABSENT],
+    required: true,
+  })
+  studentAssessmentStatus: string;
+
   @Expose()
   createdAt: string;
 
@@ -91,6 +104,9 @@ export class TrackAssessmentDto {
     this.groupId = obj?.groupId ? `${obj.groupId}` : "";
     this.subject = obj?.subject ? `${obj.subject}` : "";
     this.date = obj?.date ? `${obj.date}` : "";
+    this.studentAssessmentStatus = obj?.studentAssessmentStatus
+      ? `${obj.studentAssessmentStatus}`
+      : "";
     this.createdAt = obj?.created_at ? `${obj.created_at}` : "";
     this.updatedAt = obj?.updated_at ? `${obj.updated_at}` : "";
   }

--- a/src/trackAssessment/enums/statuses.enum.ts
+++ b/src/trackAssessment/enums/statuses.enum.ts
@@ -1,0 +1,9 @@
+export enum NipunStatus {
+  NIPUN = "NIPUN",
+  NIPUN_READY = "NIPUN_READY",
+}
+
+export enum StudentAssessmentStatus {
+  COMPLETED = "COMPLETED",
+  ABSENT = "ABSENT",
+}

--- a/src/trackAssessment/enums/statuses.enum.ts
+++ b/src/trackAssessment/enums/statuses.enum.ts
@@ -1,8 +1,3 @@
-export enum NipunStatus {
-  NIPUN = "NIPUN",
-  NIPUN_READY = "NIPUN_READY",
-}
-
 export enum StudentAssessmentStatus {
   COMPLETED = "COMPLETED",
   ABSENT = "ABSENT",

--- a/src/trackAssessment/trackassessment.controller.ts
+++ b/src/trackAssessment/trackassessment.controller.ts
@@ -102,11 +102,15 @@ export class AssessmentController {
   @ApiQuery({ name: "toDate", required: false })
   @ApiQuery({ name: "groupId", required: false })
   @ApiQuery({ name: "subject", required: false })
+  @ApiQuery({ name: "teacherId", required: false })
+  @ApiQuery({ name: "studentId", required: false })
   public async trackassessmentFilter(
     @Query("fromDate") date: string,
     @Query("toDate") toDate: string,
     @Query("groupId") groupId: string,
     @Query("subject") subject: string,
+    @Query("teacherId") teacherId: string,
+    @Query("studentId") studentId: string,
     @Req() request: Request
   ) {
     return this.service.trackAssessmentFilter(
@@ -114,6 +118,8 @@ export class AssessmentController {
       toDate,
       groupId,
       subject,
+      teacherId,
+      studentId,
       request
     );
   }

--- a/src/trackAssessment/trackassessment.controller.ts
+++ b/src/trackAssessment/trackassessment.controller.ts
@@ -20,6 +20,8 @@ import {
   Post,
   Body,
   Query,
+  UsePipes,
+  ValidationPipe,
 } from "@nestjs/common";
 import { TrackAssessmentService } from "src/adapters/hasura/trackassessment.adapter";
 import { TrackAssessmentDto } from "./dto/trackassessment.dto";
@@ -38,6 +40,7 @@ export class AssessmentController {
   @ApiBody({ type: TrackAssessmentDto })
   @ApiForbiddenResponse({ description: "Forbidden" })
   @UseInterceptors(ClassSerializerInterceptor)
+  @UsePipes(new ValidationPipe({}))
   public async createAssessment(
     @Req() request: Request,
     @Body() assessmentDto: TrackAssessmentDto

--- a/src/trackAssessment/trackassessment.controller.ts
+++ b/src/trackAssessment/trackassessment.controller.ts
@@ -23,6 +23,7 @@ import {
 } from "@nestjs/common";
 import { TrackAssessmentService } from "src/adapters/hasura/trackassessment.adapter";
 import { TrackAssessmentDto } from "./dto/trackassessment.dto";
+import { isUUID } from "class-validator";
 
 @ApiTags("Track Assessment")
 @Controller("trackassessment")
@@ -98,8 +99,8 @@ export class AssessmentController {
   @ApiBasicAuth("access-token")
   @ApiOkResponse({ description: " Ok." })
   @ApiForbiddenResponse({ description: "Forbidden" })
-  @ApiQuery({ name: "fromDate", required: false })
-  @ApiQuery({ name: "toDate", required: false })
+  @ApiQuery({ name: "fromDate", required: true })
+  @ApiQuery({ name: "toDate", required: true })
   @ApiQuery({ name: "groupId", required: false })
   @ApiQuery({ name: "subject", required: false })
   @ApiQuery({ name: "teacherId", required: false })


### PR DESCRIPTION
**Changes summary:-**

1. Added `groupId` in below APIs:
- POST /api/v1/monitortracking/search
- POST /api/v1/monitortracking
- PUT /api/v1/monitortracking/{id}
2. Added `teacherId` & `studentId` filters in **GET /api/v1/trackassessment**
3. Fixed validations in **GET /api/v1/trackassessment**
4. Added `studentAssessmentStatus` support (COMPLETED or ABSENT) in CU APIs for trackassessment